### PR TITLE
feat: HS-lite module switches to disable federation/E2EE/push/voip/presence and retain core APIs

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -733,139 +733,141 @@ func Setup(
 
 	// Push rules
 
-	v3mux.Handle("/pushrules",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("missing trailing slash"),
-			}
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+	if cfg.Features.EnablePushRules {
+		v3mux.Handle("/pushrules",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("missing trailing slash"),
+				}
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return GetAllPushRules(req.Context(), device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return GetAllPushRules(req.Context(), device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("scope, kind and rule ID must be specified"),
-			}
-		}),
-	).Methods(http.MethodPut)
+		v3mux.Handle("/pushrules/",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("scope, kind and rule ID must be specified"),
+				}
+			}),
+		).Methods(http.MethodPut)
 
-	v3mux.Handle("/pushrules/{scope}/",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetPushRulesByScope(req.Context(), vars["scope"], device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}/",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return GetPushRulesByScope(req.Context(), vars["scope"], device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("missing trailing slash after scope"),
-			}
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("missing trailing slash after scope"),
+				}
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope:[^/]+/?}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("kind and rule ID must be specified"),
-			}
-		}),
-	).Methods(http.MethodPut)
+		v3mux.Handle("/pushrules/{scope:[^/]+/?}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("kind and rule ID must be specified"),
+				}
+			}),
+		).Methods(http.MethodPut)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetPushRulesByKind(req.Context(), vars["scope"], vars["kind"], device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}/{kind}/",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return GetPushRulesByKind(req.Context(), vars["scope"], vars["kind"], device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("missing trailing slash after kind"),
-			}
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}/{kind}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("missing trailing slash after kind"),
+				}
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope}/{kind:[^/]+/?}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.InvalidParam("rule ID must be specified"),
-			}
-		}),
-	).Methods(http.MethodPut)
+		v3mux.Handle("/pushrules/{scope}/{kind:[^/]+/?}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: spec.InvalidParam("rule ID must be specified"),
+				}
+			}),
+		).Methods(http.MethodPut)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetPushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return GetPushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			if r := rateLimits.Limit(req, device); r != nil {
-				return *r
-			}
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			query := req.URL.Query()
-			return PutPushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], query.Get("after"), query.Get("before"), req.Body, device, userAPI)
-		}),
-	).Methods(http.MethodPut)
+		v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				if r := rateLimits.Limit(req, device); r != nil {
+					return *r
+				}
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				query := req.URL.Query()
+				return PutPushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], query.Get("after"), query.Get("before"), req.Body, device, userAPI)
+			}),
+		).Methods(http.MethodPut)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return DeletePushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], device, userAPI)
-		}),
-	).Methods(http.MethodDelete)
+		v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return DeletePushRuleByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], device, userAPI)
+			}),
+		).Methods(http.MethodDelete)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}/{attr}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetPushRuleAttrByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], vars["attr"], device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+		v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}/{attr}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return GetPushRuleAttrByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], vars["attr"], device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}/{attr}",
-		httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return PutPushRuleAttrByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], vars["attr"], req.Body, device, userAPI)
-		}),
-	).Methods(http.MethodPut)
+		v3mux.Handle("/pushrules/{scope}/{kind}/{ruleID}/{attr}",
+			httputil.MakeAuthAPI("push_rules", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return PutPushRuleAttrByRuleID(req.Context(), vars["scope"], vars["kind"], vars["ruleID"], vars["attr"], req.Body, device, userAPI)
+			}),
+		).Methods(http.MethodPut)
+	}
 
 	// Element user settings
 
@@ -955,14 +957,16 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
-	v3mux.Handle("/voip/turnServer",
-		httputil.MakeAuthAPI("turn_server", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			if r := rateLimits.Limit(req, device); r != nil {
-				return *r
-			}
-			return RequestTurnServer(req, device, cfg)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+	if cfg.Features.EnableVoIP {
+		v3mux.Handle("/voip/turnServer",
+			httputil.MakeAuthAPI("turn_server", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				if r := rateLimits.Limit(req, device); r != nil {
+					return *r
+				}
+				return RequestTurnServer(req, device, cfg)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
+	}
 
 	v3mux.Handle("/thirdparty/protocols",
 		httputil.MakeAuthAPI("thirdparty_protocols", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
@@ -1195,20 +1199,22 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushers",
-		httputil.MakeAuthAPI("get_pushers", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return GetPushers(req, device, userAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+	if cfg.Features.EnablePushers {
+		v3mux.Handle("/pushers",
+			httputil.MakeAuthAPI("get_pushers", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				return GetPushers(req, device, userAPI)
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/pushers/set",
-		httputil.MakeAuthAPI("set_pushers", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			if r := rateLimits.Limit(req, device); r != nil {
-				return *r
-			}
-			return SetPusher(req, device, userAPI)
-		}),
-	).Methods(http.MethodPost, http.MethodOptions)
+		v3mux.Handle("/pushers/set",
+			httputil.MakeAuthAPI("set_pushers", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				if r := rateLimits.Limit(req, device); r != nil {
+					return *r
+				}
+				return SetPusher(req, device, userAPI)
+			}),
+		).Methods(http.MethodPost, http.MethodOptions)
+	}
 
 	// Stub implementations for sytest
 	v3mux.Handle("/events",
@@ -1488,24 +1494,26 @@ func Setup(
 			return SetReceipt(req, userAPI, syncProducer, device, vars["roomId"], vars["receiptType"], vars["eventId"])
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
-	v3mux.Handle("/presence/{userId}/status",
-		httputil.MakeAuthAPI("set_presence", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return SetPresence(req, cfg, device, syncProducer, vars["userId"])
-		}),
-	).Methods(http.MethodPut, http.MethodOptions)
-	v3mux.Handle("/presence/{userId}/status",
-		httputil.MakeAuthAPI("get_presence", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetPresence(req, device, natsClient, cfg.Matrix.JetStream.Prefixed(jetstream.RequestPresence), vars["userId"])
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
+	if cfg.Features.EnablePresence {
+		v3mux.Handle("/presence/{userId}/status",
+			httputil.MakeAuthAPI("set_presence", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return SetPresence(req, cfg, device, syncProducer, vars["userId"])
+			}),
+		).Methods(http.MethodPut, http.MethodOptions)
+		v3mux.Handle("/presence/{userId}/status",
+			httputil.MakeAuthAPI("get_presence", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+				vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+				if err != nil {
+					return util.ErrorResponse(err)
+				}
+				return GetPresence(req, device, natsClient, cfg.Matrix.JetStream.Prefixed(jetstream.RequestPresence), vars["userId"])
+			}),
+		).Methods(http.MethodGet, http.MethodOptions)
+	}
 
 	v3mux.Handle("/rooms/{roomID}/joined_members",
 		httputil.MakeAuthAPI("rooms_members", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -1274,6 +1274,7 @@ func Setup(
 		}, httputil.WithAllowGuests()),
 	).Methods(http.MethodGet, http.MethodOptions)
 
+	if cfg.KeyServer.Enabled {
 	// Key Backup Versions (Metadata)
 
 	getBackupKeysVersion := httputil.MakeAuthAPI("get_backup_keys_version", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
@@ -1481,6 +1482,7 @@ func Setup(
 			return ClaimKeys(req, userAPI)
 		}, httputil.WithAllowGuests()),
 	).Methods(http.MethodPost, http.MethodOptions)
+	}
 	v3mux.Handle("/rooms/{roomId}/receipt/{receiptType}/{eventId}",
 		httputil.MakeAuthAPI(spec.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			if r := rateLimits.Limit(req, device); r != nil {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -1274,7 +1274,7 @@ func Setup(
 		}, httputil.WithAllowGuests()),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	if cfg.KeyServer.Enabled {
+	if dendriteCfg.KeyServer.Enabled {
 	// Key Backup Versions (Metadata)
 
 	getBackupKeysVersion := httputil.MakeAuthAPI("get_backup_keys_version", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/docs/hs-lite-config-example.yaml
+++ b/docs/hs-lite-config-example.yaml
@@ -1,0 +1,27 @@
+version: 2
+
+federation_api:
+  enabled: false
+
+relay_api:
+  enabled: false
+
+key_server:
+  enabled: false
+
+client_api:
+  features:
+    enable_presence: false
+    enable_voip: false
+    enable_pushers: false
+    enable_push_rules: false
+
+media_api:
+  base_path: ./media
+
+room_server: {}
+sync_api: {}
+user_api: {}
+app_service_api:
+  internal_api:
+    listen: http://localhost:7777

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -5,9 +5,17 @@ import (
 	"time"
 )
 
+type ClientFeatures struct {
+	EnablePresence  bool `yaml:"enable_presence"`
+	EnableVoIP      bool `yaml:"enable_voip"`
+	EnablePushers   bool `yaml:"enable_pushers"`
+	EnablePushRules bool `yaml:"enable_push_rules"`
+}
+
 type ClientAPI struct {
 	Matrix  *Global  `yaml:"-"`
 	Derived *Derived `yaml:"-"` // TODO: Nuke Derived from orbit
+	Features ClientFeatures `yaml:"features"`
 
 	// If set disables new users from registering (except via shared
 	// secrets)
@@ -69,6 +77,12 @@ func (c *ClientAPI) Defaults(opts DefaultOpts) {
 	c.RegistrationDisabled = true
 	c.OpenRegistrationWithoutVerificationEnabled = false
 	c.RateLimiting.Defaults()
+	c.Features = ClientFeatures{
+		EnablePresence:  true,
+		EnableVoIP:      true,
+		EnablePushers:   true,
+		EnablePushRules: true,
+	}
 }
 
 func (c *ClientAPI) Verify(configErrs *ConfigErrors) {

--- a/setup/config/config_federationapi.go
+++ b/setup/config/config_federationapi.go
@@ -7,6 +7,7 @@ import (
 
 type FederationAPI struct {
 	Matrix *Global `yaml:"-"`
+	Enabled bool `yaml:"enabled"`
 
 	// The database stores information used by the federation destination queues to
 	// send transactions to remote servers.
@@ -53,6 +54,7 @@ type FederationAPI struct {
 }
 
 func (c *FederationAPI) Defaults(opts DefaultOpts) {
+	c.Enabled = true
 	c.FederationMaxRetries = 16
 	c.P2PFederationRetriesUntilAssumedOffline = 1
 	c.DisableTLSValidation = false

--- a/setup/config/config_keyserver.go
+++ b/setup/config/config_keyserver.go
@@ -2,11 +2,13 @@ package config
 
 type KeyServer struct {
 	Matrix *Global `yaml:"-"`
+	Enabled bool `yaml:"enabled"`
 
 	Database DatabaseOptions `yaml:"database,omitempty"`
 }
 
 func (c *KeyServer) Defaults(opts DefaultOpts) {
+	c.Enabled = true
 	if opts.Generate {
 		if !opts.SingleDatabase {
 			c.Database.ConnectionString = "file:keyserver.db"

--- a/setup/config/config_relayapi.go
+++ b/setup/config/config_relayapi.go
@@ -8,6 +8,7 @@ package config
 
 type RelayAPI struct {
 	Matrix *Global `yaml:"-"`
+	Enabled bool `yaml:"enabled"`
 
 	// The database stores information used by the relay queue to
 	// forward transactions to remote servers.
@@ -15,6 +16,7 @@ type RelayAPI struct {
 }
 
 func (c *RelayAPI) Defaults(opts DefaultOpts) {
+	c.Enabled = true
 	if opts.Generate {
 		if !opts.SingleDatabase {
 			c.Database.ConnectionString = "file:relayapi.db"

--- a/setup/monolith.go
+++ b/setup/monolith.go
@@ -67,13 +67,15 @@ func (m *Monolith) AddAllPublicRoutes(
 		m.FederationAPI, m.UserAPI, userDirectoryProvider,
 		m.ExtPublicRoomsProvider, enableMetrics,
 	)
-	federationapi.AddPublicRoutes(
-		processCtx, routers, cfg, natsInstance, m.UserAPI, m.FedClient, m.KeyRing, m.RoomserverAPI, m.FederationAPI, enableMetrics,
-	)
+	if cfg.FederationAPI.Enabled {
+		federationapi.AddPublicRoutes(
+			processCtx, routers, cfg, natsInstance, m.UserAPI, m.FedClient, m.KeyRing, m.RoomserverAPI, m.FederationAPI, enableMetrics,
+		)
+	}
 	mediaapi.AddPublicRoutes(routers, cm, cfg, m.UserAPI, m.Client, m.FedClient, m.KeyRing)
 	syncapi.AddPublicRoutes(processCtx, routers, cfg, cm, natsInstance, m.UserAPI, m.RoomserverAPI, caches, enableMetrics)
 
-	if m.RelayAPI != nil {
+	if cfg.RelayAPI.Enabled && m.RelayAPI != nil {
 		relayapi.AddPublicRoutes(routers, cfg, m.KeyRing, m.RelayAPI)
 	}
 }


### PR DESCRIPTION
# feat: HS-lite module switches to disable federation/E2EE/push/voip/presence and retain core APIs

## Summary

This PR implements configurable toggles to create a "HS-lite" (Homeserver-lite) version of Dendrite suitable for chat aggregation SaaS products. It adds boolean flags to selectively disable non-essential modules while preserving core Matrix functionality required for bridging (login/whoami, room management, messaging, /sync, media, AppService support).

**Key Changes:**
- Added `Enabled` flags to `FederationAPI`, `RelayAPI`, and `KeyServer` configs (default: `true`)
- Added `ClientFeatures` struct to `ClientAPI` config with toggles for `EnablePresence`, `EnableVoIP`, `EnablePushers`, `EnablePushRules` (default: `true`)
- Modified `setup/monolith.go` to conditionally register federation and relay public routes
- Modified `clientapi/routing/routing.go` to conditionally register presence, VoIP, pushers, push rules, and E2EE routes
- Added example HS-lite configuration file at `docs/hs-lite-config-example.yaml`

**Backwards Compatibility:** All flags default to `true`, preserving existing behavior when no configuration changes are made.

## Review & Testing Checklist for Human

- [ ] **Test HS-lite configuration actually disables routes**: Use the example config to verify that federation, relay, presence, VoIP, pushers, push rules, and E2EE endpoints return 404 when disabled
- [ ] **Verify core APIs still function**: Test login, whoami, room management, messaging, /sync, media upload/download, and AppService functionality with HS-lite config
- [ ] **Review E2EE route gating accuracy**: Check that the large block of E2EE routes (lines 1277-1483) are correctly identified and that no critical routes were missed or incorrectly gated
- [ ] **Validate backwards compatibility**: Ensure existing installations continue to work unchanged with default configuration
- [ ] **Test configuration validation**: Verify invalid config values are properly handled and error messages are clear

**Recommended Test Plan:**
1. Start Dendrite with default config - verify all routes work as before
2. Start Dendrite with HS-lite config - verify disabled routes return 404
3. Test core bridge functionality (AppService transactions, user impersonation) with HS-lite config
4. Verify media upload/download, room creation, messaging, and /sync work with disabled modules

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Configuration Layer"
        FedConfig["setup/config/config_federationapi.go<br/>+ Enabled bool"]:::major-edit
        RelayConfig["setup/config/config_relayapi.go<br/>+ Enabled bool"]:::major-edit
        ClientConfig["setup/config/config_clientapi.go<br/>+ ClientFeatures struct"]:::major-edit
        KeyConfig["setup/config/config_keyserver.go<br/>+ Enabled bool"]:::major-edit
    end
    
    subgraph "Route Assembly"
        Monolith["setup/monolith.go<br/>AddAllPublicRoutes()"]:::major-edit
        ClientRouting["clientapi/routing/routing.go<br/>Setup()"]:::major-edit
    end
    
    subgraph "Example Config"
        HSLiteConfig["docs/hs-lite-config-example.yaml<br/>federation_api.enabled: false<br/>etc."]:::minor-edit
    end
    
    FedConfig --> Monolith
    RelayConfig --> Monolith
    ClientConfig --> ClientRouting
    KeyConfig --> ClientRouting
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Potential Issues to Watch:**
- Module interdependencies may cause unexpected behavior when features are disabled
- The E2EE route gating wraps a large block (lines 1277-1483) - double-check that all routes in this section should be gated together
- Configuration validation could be enhanced to warn about incompatible combinations
- No comprehensive test coverage for all module combination scenarios

**Implementation Context:**
This work supports a multi-platform chat aggregation SaaS product using Matrix protocol + Bridge technology. The goal is to create a simplified homeserver that retains bridging capabilities while removing enterprise federation, E2EE, and modern client features not needed for the use case.

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/f25dc89c979346968f8bdb889b51690b
- Requested by: @meovary150