### PR TITLE
Fix refresh token database functionality

### DIFF
--- a/userapi/storage/interface.go
+++ b/userapi/storage/interface.go
@@ -78,6 +78,9 @@ type Device interface {
 	CreateDevice(ctx context.Context, localpart string, serverName spec.ServerName, deviceID *string, accessToken string, displayName *string, ipAddr, userAgent string) (dev *api.Device, returnErr error)
 	// CreateDeviceWithRefreshToken creates a device with both access and refresh tokens
 	CreateDeviceWithRefreshToken(ctx context.Context, localpart string, serverName spec.ServerName, deviceID *string, accessToken, refreshToken string, displayName *string, ipAddr, userAgent string) (dev *api.Device, returnErr error)
+	QueryRefreshToken(ctx context.Context, refreshToken string) (*api.Device, error)
+	// UpdateRefreshToken updates the refresh token for a device
+	UpdateRefreshToken(ctx context.Context, deviceID, userID, oldRefreshToken, newAccessToken, newRefreshToken string) error
 	// UpdateDeviceTokens updates both access and refresh tokens for a device
 	UpdateDeviceTokens(ctx context.Context, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error
 	UpdateDevice(ctx context.Context, localpart string, serverName spec.ServerName, deviceID string, displayName *string) error

--- a/userapi/storage/postgres/deltas/20250101000000_refresh_tokens.go
+++ b/userapi/storage/postgres/deltas/20250101000000_refresh_tokens.go
@@ -1,0 +1,27 @@
+package deltas
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func UpRefreshTokens(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE userapi_devices ADD COLUMN IF NOT EXISTS refresh_token TEXT;
+CREATE INDEX IF NOT EXISTS userapi_devices_refresh_token_idx ON userapi_devices(refresh_token);`)
+	if err != nil {
+		return fmt.Errorf("failed to execute upgrade: %w", err)
+	}
+	return nil
+}
+
+func DownRefreshTokens(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+	DROP INDEX IF EXISTS userapi_devices_refresh_token_idx;
+	ALTER TABLE userapi_devices DROP COLUMN refresh_token;`)
+	if err != nil {
+		return fmt.Errorf("failed to execute downgrade: %w", err)
+	}
+	return nil
+}

--- a/userapi/storage/postgres/devices_table.go
+++ b/userapi/storage/postgres/devices_table.go
@@ -120,6 +120,10 @@ func NewPostgresDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Dev
 		Version: "userapi: add last_seen_ts",
 		Up:      deltas.UpLastSeenTSIP,
 	})
+	m.AddMigrations(sqlutil.Migration{
+		Version: "userapi: add refresh_token",
+		Up:      deltas.UpRefreshTokens,
+	})
 	err = m.Up(context.Background())
 	if err != nil {
 		return nil, err
@@ -338,5 +342,11 @@ func (s *devicesStatements) UpdateDeviceLastSeen(ctx context.Context, txn *sql.T
 	lastSeenTs := time.Now().UnixNano() / 1000000
 	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
 	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, userAgent, localpart, serverName, deviceID)
+	return err
+}
+
+func (s *devicesStatements) UpdateDeviceTokens(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error {
+	stmt := sqlutil.TxStmt(txn, s.updateDeviceTokensStmt)
+	_, err := stmt.ExecContext(ctx, accessToken, refreshToken, localpart, serverName, deviceID)
 	return err
 }

--- a/userapi/storage/postgres/devices_table.go
+++ b/userapi/storage/postgres/devices_table.go
@@ -93,18 +93,31 @@ const selectDevicesByIDSQL = "" +
 const updateDeviceLastSeen = "" +
 	"UPDATE userapi_devices SET last_seen_ts = $1, ip = $2, user_agent = $3 WHERE localpart = $4 AND server_name = $5 AND device_id = $6"
 
+const selectDeviceByRefreshTokenSQL = "" +
+	"SELECT session_id, device_id, localpart, server_name, access_token FROM userapi_devices WHERE refresh_token = $1"
+
+const updateDeviceTokensSQL = "" +
+	"UPDATE userapi_devices SET access_token = $1, refresh_token = $2 WHERE localpart = $3 AND server_name = $4 AND device_id = $5"
+
+const insertDeviceWithRefreshTokenSQL = "" +
+	"INSERT INTO userapi_devices(device_id, localpart, server_name, access_token, refresh_token, created_ts, display_name, last_seen_ts, ip, user_agent) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)" +
+	" RETURNING session_id"
+
 type devicesStatements struct {
-	insertDeviceStmt             *sql.Stmt
-	selectDeviceByTokenStmt      *sql.Stmt
-	selectDeviceByIDStmt         *sql.Stmt
-	selectDevicesByLocalpartStmt *sql.Stmt
-	selectDevicesByIDStmt        *sql.Stmt
-	updateDeviceNameStmt         *sql.Stmt
-	updateDeviceLastSeenStmt     *sql.Stmt
-	deleteDeviceStmt             *sql.Stmt
-	deleteDevicesByLocalpartStmt *sql.Stmt
-	deleteDevicesStmt            *sql.Stmt
-	serverName                   spec.ServerName
+	insertDeviceStmt                *sql.Stmt
+	insertDeviceWithRefreshTokenStmt *sql.Stmt
+	selectDeviceByTokenStmt         *sql.Stmt
+	selectDeviceByRefreshTokenStmt  *sql.Stmt
+	selectDeviceByIDStmt            *sql.Stmt
+	selectDevicesByLocalpartStmt    *sql.Stmt
+	selectDevicesByIDStmt           *sql.Stmt
+	updateDeviceNameStmt            *sql.Stmt
+	updateDeviceLastSeenStmt        *sql.Stmt
+	updateDeviceTokensStmt          *sql.Stmt
+	deleteDeviceStmt                *sql.Stmt
+	deleteDevicesByLocalpartStmt    *sql.Stmt
+	deleteDevicesStmt               *sql.Stmt
+	serverName                      spec.ServerName
 }
 
 func NewPostgresDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.DevicesTable, error) {
@@ -130,7 +143,9 @@ func NewPostgresDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Dev
 	}
 	return s, sqlutil.StatementList{
 		{&s.insertDeviceStmt, insertDeviceSQL},
+		{&s.insertDeviceWithRefreshTokenStmt, insertDeviceWithRefreshTokenSQL},
 		{&s.selectDeviceByTokenStmt, selectDeviceByTokenSQL},
+		{&s.selectDeviceByRefreshTokenStmt, selectDeviceByRefreshTokenSQL},
 		{&s.selectDeviceByIDStmt, selectDeviceByIDSQL},
 		{&s.selectDevicesByLocalpartStmt, selectDevicesByLocalpartSQL},
 		{&s.updateDeviceNameStmt, updateDeviceNameSQL},
@@ -139,6 +154,7 @@ func NewPostgresDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Dev
 		{&s.deleteDevicesStmt, deleteDevicesSQL},
 		{&s.selectDevicesByIDStmt, selectDevicesByIDSQL},
 		{&s.updateDeviceLastSeenStmt, updateDeviceLastSeen},
+		{&s.updateDeviceTokensStmt, updateDeviceTokensSQL},
 	}.Prepare(db)
 }
 
@@ -343,6 +359,48 @@ func (s *devicesStatements) UpdateDeviceLastSeen(ctx context.Context, txn *sql.T
 	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
 	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, userAgent, localpart, serverName, deviceID)
 	return err
+}
+
+func (s *devicesStatements) InsertDeviceWithRefreshToken(
+	ctx context.Context, txn *sql.Tx, id string,
+	localpart string, serverName spec.ServerName,
+	accessToken, refreshToken string, displayName *string, ipAddr, userAgent string,
+) (*api.Device, error) {
+	createdTimeMS := time.Now().UnixNano() / 1000000
+	var sessionID int64
+	stmt := sqlutil.TxStmt(txn, s.insertDeviceWithRefreshTokenStmt)
+	if err := stmt.QueryRowContext(ctx, id, localpart, serverName, accessToken, refreshToken, createdTimeMS, displayName, createdTimeMS, ipAddr, userAgent).Scan(&sessionID); err != nil {
+		return nil, fmt.Errorf("insertDeviceWithRefreshTokenStmt: %w", err)
+	}
+	dev := &api.Device{
+		ID:           id,
+		UserID:       userutil.MakeUserID(localpart, serverName),
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		SessionID:    sessionID,
+		LastSeenTS:   createdTimeMS,
+		LastSeenIP:   ipAddr,
+		UserAgent:    userAgent,
+	}
+	if displayName != nil {
+		dev.DisplayName = *displayName
+	}
+	return dev, nil
+}
+
+func (s *devicesStatements) SelectDeviceByRefreshToken(
+	ctx context.Context, refreshToken string,
+) (*api.Device, error) {
+	var dev api.Device
+	var localpart string
+	var serverName spec.ServerName
+	stmt := s.selectDeviceByRefreshTokenStmt
+	err := stmt.QueryRowContext(ctx, refreshToken).Scan(&dev.SessionID, &dev.ID, &localpart, &serverName, &dev.AccessToken)
+	if err == nil {
+		dev.UserID = userutil.MakeUserID(localpart, serverName)
+		dev.RefreshToken = refreshToken
+	}
+	return &dev, err
 }
 
 func (s *devicesStatements) UpdateDeviceTokens(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error {

--- a/userapi/storage/shared/storage.go
+++ b/userapi/storage/shared/storage.go
@@ -703,7 +703,7 @@ func (d *Database) CreateDeviceWithRefreshToken(
 }
 
 func (d *Database) QueryRefreshToken(ctx context.Context, refreshToken string) (*api.Device, error) {
-	return d.DevicesTable.SelectDeviceByRefreshToken(ctx, refreshToken)
+	return d.Devices.SelectDeviceByRefreshToken(ctx, refreshToken)
 }
 
 func (d *Database) UpdateRefreshToken(ctx context.Context, deviceID, userID, oldRefreshToken, newAccessToken, newRefreshToken string) error {
@@ -712,12 +712,12 @@ func (d *Database) UpdateRefreshToken(ctx context.Context, deviceID, userID, old
 		return err
 	}
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-		return d.DevicesTable.UpdateDeviceTokens(ctx, txn, localpart, domain, deviceID, newAccessToken, newRefreshToken)
+		return d.Devices.UpdateDeviceTokens(ctx, txn, localpart, domain, deviceID, newAccessToken, newRefreshToken)
 	})
 }
 
 func (d *Database) GetDeviceByRefreshToken(ctx context.Context, refreshToken string) (*api.Device, error) {
-	return d.DevicesTable.SelectDeviceByRefreshToken(ctx, refreshToken)
+	return d.Devices.SelectDeviceByRefreshToken(ctx, refreshToken)
 }
 
 func (d *Database) UpdateDeviceTokens(ctx context.Context, userID string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error {
@@ -729,7 +729,7 @@ func (d *Database) UpdateDeviceTokens(ctx context.Context, userID string, server
 		return fmt.Errorf("server name %s does not match %s", domain, serverName)
 	}
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-		return d.DevicesTable.UpdateDeviceTokens(ctx, txn, localpart, serverName, deviceID, accessToken, refreshToken)
+		return d.Devices.UpdateDeviceTokens(ctx, txn, localpart, serverName, deviceID, accessToken, refreshToken)
 	})
 }
 

--- a/userapi/storage/sqlite3/deltas/20250101000000_refresh_tokens.go
+++ b/userapi/storage/sqlite3/deltas/20250101000000_refresh_tokens.go
@@ -1,0 +1,65 @@
+package deltas
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func UpRefreshTokens(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+    ALTER TABLE userapi_devices RENAME TO userapi_devices_tmp;
+    CREATE TABLE userapi_devices (
+        access_token TEXT PRIMARY KEY,
+        session_id INTEGER,
+        device_id TEXT,
+        localpart TEXT,
+        server_name TEXT NOT NULL,
+        created_ts BIGINT,
+        display_name TEXT,
+        last_seen_ts BIGINT,
+        ip TEXT,
+        user_agent TEXT,
+        refresh_token TEXT,
+        UNIQUE (localpart, server_name, device_id)
+    );
+    CREATE INDEX IF NOT EXISTS userapi_devices_refresh_token_idx ON userapi_devices(refresh_token);
+    INSERT INTO userapi_devices (
+        access_token, session_id, device_id, localpart, server_name, created_ts, display_name, last_seen_ts, ip, user_agent, refresh_token
+    ) SELECT
+        access_token, session_id, device_id, localpart, server_name, created_ts, display_name, last_seen_ts, ip, user_agent, NULL
+    FROM userapi_devices_tmp;
+    DROP TABLE userapi_devices_tmp;`)
+	if err != nil {
+		return fmt.Errorf("failed to execute upgrade: %w", err)
+	}
+	return nil
+}
+
+func DownRefreshTokens(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE userapi_devices RENAME TO userapi_devices_tmp;
+CREATE TABLE IF NOT EXISTS userapi_devices (
+    access_token TEXT PRIMARY KEY,
+    session_id INTEGER,
+    device_id TEXT,
+    localpart TEXT,
+    server_name TEXT NOT NULL,
+    created_ts BIGINT,
+    display_name TEXT,
+    last_seen_ts BIGINT,
+    ip TEXT,
+    user_agent TEXT,
+    UNIQUE (localpart, server_name, device_id)
+);
+INSERT INTO userapi_devices (
+    access_token, session_id, device_id, localpart, server_name, created_ts, display_name, last_seen_ts, ip, user_agent
+) SELECT
+    access_token, session_id, device_id, localpart, server_name, created_ts, display_name, last_seen_ts, ip, user_agent
+FROM userapi_devices_tmp;
+DROP TABLE userapi_devices_tmp;`)
+	if err != nil {
+		return fmt.Errorf("failed to execute downgrade: %w", err)
+	}
+	return nil
+}

--- a/userapi/storage/sqlite3/devices_table.go
+++ b/userapi/storage/sqlite3/devices_table.go
@@ -106,6 +106,10 @@ func NewSQLiteDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Devic
 		Version: "userapi: add last_seen_ts",
 		Up:      deltas.UpLastSeenTSIP,
 	})
+	m.AddMigrations(sqlutil.Migration{
+		Version: "userapi: add refresh_token",
+		Up:      deltas.UpRefreshTokens,
+	})
 	if err = m.Up(context.Background()); err != nil {
 		return nil, err
 	}
@@ -359,5 +363,11 @@ func (s *devicesStatements) UpdateDeviceLastSeen(ctx context.Context, txn *sql.T
 	lastSeenTs := time.Now().UnixNano() / 1000000
 	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
 	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, userAgent, localpart, serverName, deviceID)
+	return err
+}
+
+func (s *devicesStatements) UpdateDeviceTokens(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error {
+	stmt := sqlutil.TxStmt(txn, s.updateDeviceTokensStmt)
+	_, err := stmt.ExecContext(ctx, accessToken, refreshToken, localpart, serverName, deviceID)
 	return err
 }

--- a/userapi/storage/sqlite3/devices_table.go
+++ b/userapi/storage/sqlite3/devices_table.go
@@ -77,19 +77,32 @@ const selectDevicesByIDSQL = "" +
 const updateDeviceLastSeen = "" +
 	"UPDATE userapi_devices SET last_seen_ts = $1, ip = $2, user_agent = $3 WHERE localpart = $4 AND server_name = $5 AND device_id = $6"
 
+const selectDeviceByRefreshTokenSQL = "" +
+	"SELECT session_id, device_id, localpart, server_name, access_token FROM userapi_devices WHERE refresh_token = $1"
+
+const updateDeviceTokensSQL = "" +
+	"UPDATE userapi_devices SET access_token = $1, refresh_token = $2 WHERE localpart = $3 AND server_name = $4 AND device_id = $5"
+
+const insertDeviceWithRefreshTokenSQL = "" +
+	"INSERT INTO userapi_devices (device_id, localpart, server_name, access_token, refresh_token, created_ts, display_name, session_id, last_seen_ts, ip, user_agent)" +
+	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"
+
 type devicesStatements struct {
-	db                           *sql.DB
-	insertDeviceStmt             *sql.Stmt
-	selectDevicesCountStmt       *sql.Stmt
-	selectDeviceByTokenStmt      *sql.Stmt
-	selectDeviceByIDStmt         *sql.Stmt
-	selectDevicesByIDStmt        *sql.Stmt
-	selectDevicesByLocalpartStmt *sql.Stmt
-	updateDeviceNameStmt         *sql.Stmt
-	updateDeviceLastSeenStmt     *sql.Stmt
-	deleteDeviceStmt             *sql.Stmt
-	deleteDevicesByLocalpartStmt *sql.Stmt
-	serverName                   spec.ServerName
+	db                              *sql.DB
+	insertDeviceStmt                *sql.Stmt
+	insertDeviceWithRefreshTokenStmt *sql.Stmt
+	selectDevicesCountStmt          *sql.Stmt
+	selectDeviceByTokenStmt         *sql.Stmt
+	selectDeviceByRefreshTokenStmt  *sql.Stmt
+	selectDeviceByIDStmt            *sql.Stmt
+	selectDevicesByIDStmt           *sql.Stmt
+	selectDevicesByLocalpartStmt    *sql.Stmt
+	updateDeviceNameStmt            *sql.Stmt
+	updateDeviceLastSeenStmt        *sql.Stmt
+	updateDeviceTokensStmt          *sql.Stmt
+	deleteDeviceStmt                *sql.Stmt
+	deleteDevicesByLocalpartStmt    *sql.Stmt
+	serverName                      spec.ServerName
 }
 
 func NewSQLiteDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.DevicesTable, error) {
@@ -116,8 +129,10 @@ func NewSQLiteDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Devic
 
 	return s, sqlutil.StatementList{
 		{&s.insertDeviceStmt, insertDeviceSQL},
+		{&s.insertDeviceWithRefreshTokenStmt, insertDeviceWithRefreshTokenSQL},
 		{&s.selectDevicesCountStmt, selectDevicesCountSQL},
 		{&s.selectDeviceByTokenStmt, selectDeviceByTokenSQL},
+		{&s.selectDeviceByRefreshTokenStmt, selectDeviceByRefreshTokenSQL},
 		{&s.selectDeviceByIDStmt, selectDeviceByIDSQL},
 		{&s.selectDevicesByLocalpartStmt, selectDevicesByLocalpartSQL},
 		{&s.updateDeviceNameStmt, updateDeviceNameSQL},
@@ -125,6 +140,7 @@ func NewSQLiteDevicesTable(db *sql.DB, serverName spec.ServerName) (tables.Devic
 		{&s.deleteDevicesByLocalpartStmt, deleteDevicesByLocalpartSQL},
 		{&s.selectDevicesByIDStmt, selectDevicesByIDSQL},
 		{&s.updateDeviceLastSeenStmt, updateDeviceLastSeen},
+		{&s.updateDeviceTokensStmt, updateDeviceTokensSQL},
 	}.Prepare(db)
 }
 
@@ -364,6 +380,53 @@ func (s *devicesStatements) UpdateDeviceLastSeen(ctx context.Context, txn *sql.T
 	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
 	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, userAgent, localpart, serverName, deviceID)
 	return err
+}
+
+func (s *devicesStatements) InsertDeviceWithRefreshToken(
+	ctx context.Context, txn *sql.Tx, id string,
+	localpart string, serverName spec.ServerName,
+	accessToken, refreshToken string, displayName *string, ipAddr, userAgent string,
+) (*api.Device, error) {
+	createdTimeMS := time.Now().UnixNano() / 1000000
+	var sessionID int64
+	countStmt := sqlutil.TxStmt(txn, s.selectDevicesCountStmt)
+	insertStmt := sqlutil.TxStmt(txn, s.insertDeviceWithRefreshTokenStmt)
+	if err := countStmt.QueryRowContext(ctx).Scan(&sessionID); err != nil {
+		return nil, err
+	}
+	sessionID++
+	if _, err := insertStmt.ExecContext(ctx, id, localpart, serverName, accessToken, refreshToken, createdTimeMS, displayName, sessionID, createdTimeMS, ipAddr, userAgent); err != nil {
+		return nil, err
+	}
+	dev := &api.Device{
+		ID:           id,
+		UserID:       userutil.MakeUserID(localpart, serverName),
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		SessionID:    sessionID,
+		LastSeenTS:   createdTimeMS,
+		LastSeenIP:   ipAddr,
+		UserAgent:    userAgent,
+	}
+	if displayName != nil {
+		dev.DisplayName = *displayName
+	}
+	return dev, nil
+}
+
+func (s *devicesStatements) SelectDeviceByRefreshToken(
+	ctx context.Context, refreshToken string,
+) (*api.Device, error) {
+	var dev api.Device
+	var localpart string
+	var serverName spec.ServerName
+	stmt := s.selectDeviceByRefreshTokenStmt
+	err := stmt.QueryRowContext(ctx, refreshToken).Scan(&dev.SessionID, &dev.ID, &localpart, &serverName, &dev.AccessToken)
+	if err == nil {
+		dev.UserID = userutil.MakeUserID(localpart, serverName)
+		dev.RefreshToken = refreshToken
+	}
+	return &dev, err
 }
 
 func (s *devicesStatements) UpdateDeviceTokens(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error {

--- a/userapi/storage/tables/interface.go
+++ b/userapi/storage/tables/interface.go
@@ -49,15 +49,18 @@ type AccountsTable interface {
 type DevicesTable interface {
 	InsertDevice(ctx context.Context, txn *sql.Tx, id, localpart string, serverName spec.ServerName, accessToken string, displayName *string, ipAddr, userAgent string) (*api.Device, error)
 	InsertDeviceWithSessionID(ctx context.Context, txn *sql.Tx, id, localpart string, serverName spec.ServerName, accessToken string, displayName *string, ipAddr, userAgent string, sessionID int64) (*api.Device, error)
+	InsertDeviceWithRefreshToken(ctx context.Context, txn *sql.Tx, id, localpart string, serverName spec.ServerName, accessToken, refreshToken string, displayName *string, ipAddr, userAgent string) (*api.Device, error)
 	DeleteDevice(ctx context.Context, txn *sql.Tx, id, localpart string, serverName spec.ServerName) error
 	DeleteDevices(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, devices []string) error
 	DeleteDevicesByLocalpart(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, exceptDeviceID string) error
 	UpdateDeviceName(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID string, displayName *string) error
 	SelectDeviceByToken(ctx context.Context, accessToken string) (*api.Device, error)
+	SelectDeviceByRefreshToken(ctx context.Context, refreshToken string) (*api.Device, error)
 	SelectDeviceByID(ctx context.Context, localpart string, serverName spec.ServerName, deviceID string) (*api.Device, error)
 	SelectDevicesByLocalpart(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, exceptDeviceID string) ([]api.Device, error)
 	SelectDevicesByID(ctx context.Context, deviceIDs []string) ([]api.Device, error)
 	UpdateDeviceLastSeen(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, ipAddr, userAgent string) error
+	UpdateDeviceTokens(ctx context.Context, txn *sql.Tx, localpart string, serverName spec.ServerName, deviceID, accessToken, refreshToken string) error
 }
 
 type KeyBackupTable interface {


### PR DESCRIPTION
# Fix refresh token database functionality

## Summary

This PR implements the missing database layer for refresh token functionality in Dendrite Matrix homeserver, fixing the broken Matrix v1.4 refresh token support. The current implementation had placeholder database methods that caused runtime failures when using the `/refresh` endpoint.

**Key Changes:**
- Added `refresh_token` column to `userapi_devices` table with database migrations for both PostgreSQL and SQLite
- Implemented all missing database methods: `QueryRefreshToken`, `GetDeviceByRefreshToken`, `UpdateRefreshToken`, `UpdateDeviceTokens`
- Fixed `CreateDeviceWithRefreshToken` to actually store refresh tokens in the database (was previously only setting in-memory field)
- Added comprehensive integration tests covering the full refresh token lifecycle
- Updated database interfaces to include new refresh token methods

The refresh token endpoint implementation was already complete and just needed working database methods to function properly.

## Review & Testing Checklist for Human

- [ ] **Database Migration Safety**: Verify PostgreSQL and SQLite migrations work correctly in production environments, especially the SQLite table recreation approach
- [ ] **End-to-End Refresh Flow**: Test the complete refresh token flow via `/refresh` endpoint to ensure tokens are properly stored, retrieved, and updated
- [ ] **Security Review**: Verify refresh tokens are stored securely and queries don't introduce timing attacks or token leakage
- [ ] **PostgreSQL Functionality**: Test PostgreSQL implementation since only SQLite tests passed in CI (PostgreSQL unavailable in test environment)
- [ ] **Backward Compatibility**: Confirm existing devices without refresh tokens continue to work normally

**Recommended Test Plan:**
1. Deploy to test environment with PostgreSQL
2. Create new device with refresh token via login
3. Use refresh token to get new access/refresh token pair via `/refresh` endpoint
4. Verify old refresh token is invalidated
5. Test with existing devices to ensure no regressions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    refresh_endpoint["clientapi/routing/refresh.go"]:::context
    shared_storage["userapi/storage/shared/storage.go"]:::major-edit
    device_interface["userapi/storage/interface.go"]:::minor-edit
    postgres_devices["userapi/storage/postgres/devices_table.go"]:::major-edit
    sqlite_devices["userapi/storage/sqlite3/devices_table.go"]:::major-edit
    postgres_migration["userapi/storage/postgres/deltas/20250101000000_refresh_tokens.go"]:::major-edit
    sqlite_migration["userapi/storage/sqlite3/deltas/20250101000000_refresh_tokens.go"]:::major-edit
    test_file["userapi/storage/storage_test.go"]:::minor-edit

    refresh_endpoint -->|calls| shared_storage
    shared_storage -->|implements| device_interface
    shared_storage -->|uses| postgres_devices
    shared_storage -->|uses| sqlite_devices
    postgres_devices -->|applies| postgres_migration
    sqlite_devices -->|applies| sqlite_migration
    test_file -->|tests| shared_storage

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

This implementation follows the established patterns in the Dendrite codebase for database operations and migrations. The SQLite migration uses table recreation (rename, create new, copy data, drop old) which is the standard approach for adding columns to SQLite tables. 


**Link to Devin run:** https://app.devin.ai/sessions/7f8263d15a3a4bc48f9f1a4cb369da8c  
**Requested by:** @meovary150

The refresh token functionality enables Matrix v1.4 compliance and provides better security through token rotation. All SQLite tests pass, confirming the implementation works correctly for that database backend.